### PR TITLE
Add limit to number of lines

### DIFF
--- a/gn-frontend/src/components/Note.css
+++ b/gn-frontend/src/components/Note.css
@@ -46,6 +46,11 @@ div.note {
 
 div.note p {
     white-space: pre-wrap;
+    display: -moz-box;
+    display: -webkit-box;
+    -webkit-line-clamp: 15;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
 }
 
 div.note:hover {


### PR DESCRIPTION
This feature adds a limit to the number of lines visible in each note, on the main page, and prevents notes from being too long. Any overflow beyond this point is truncated using an
ellipsis.

Note: Have to cheak for compatibility over all browsers.